### PR TITLE
when using parameters such as identityfile, execution was always 'changed'

### DIFF
--- a/library/ssh_config.py
+++ b/library/ssh_config.py
@@ -686,7 +686,7 @@ def change_host(options, **kwargs):
             if options.get(k):
                 del options[k]
                 changed = True
-        elif options.get(k) != v:
+        elif ( options.get(k) != v ) and not ( type(options.get(k)) is list and v in options.get(k) ):
             options[k] = v
             changed = True
 


### PR DESCRIPTION
some settings such as identityfile can have multiple values and are defined as lists, this caused it to always be 'changed', which is fixed with this small patch