### PR TITLE
Convert True/False values in strict_host_key_checking

### DIFF
--- a/library/ssh_config.py
+++ b/library/ssh_config.py
@@ -641,6 +641,10 @@ class ConfigParser(object):
                             key, value_
                         )
                     host_item_content += sub_content
+                elif value is True:
+                    host_item_content += "    {0} yes\n".format(key)
+                elif value is False:
+                    host_item_content += "    {0} no\n".format(key)
                 else:
                     host_item_content += "    {0} {1}\n".format(
                         key, value
@@ -707,7 +711,7 @@ def main():
             proxycommand=dict(default=None, type='str'),
             strict_host_key_checking=dict(
                 default=None,
-                choices=['yes', 'no', 'ask']
+                choices=['yes', 'no', 'ask', True, False]
             ),
         ),
         supports_check_mode=True

--- a/test/roles/normal-user/tasks/main.yml
+++ b/test/roles/normal-user/tasks/main.yml
@@ -66,3 +66,24 @@
     host=example.com
     strict_host_key_checking=yes
 - include: _assert.yml option=stricthostkeychecking value=yes
+
+- name: Test host key checking with lax config
+  ssh_config:
+    user: vagrant
+    host: example.com
+    strict_host_key_checking: true
+- include: _assert.yml option=stricthostkeychecking value=yes
+
+- name: Test no host key checking with lax config
+  ssh_config:
+    user: vagrant
+    host: example.com
+    strict_host_key_checking: false
+- include: _assert.yml option=stricthostkeychecking value=no
+
+- name: Test ask host key checking with lax config
+  ssh_config:
+    user: vagrant
+    host: example.com
+    strict_host_key_checking: ask
+- include: _assert.yml option=stricthostkeychecking value=ask


### PR DESCRIPTION
This PR converts True/False values into yes/no for strict_host_key_checking, and fix the full yaml for playbooks.

For example

```yaml
- ssh_config:
    user: vagrant
    host: example.com
    strict_host_key_checking: true
```

is equivalent to 

```yaml
- ssh_config: >
    user=vagrant
    host=example.com
    strict_host_key_checking=yes
```