### PR TITLE
Update ssh_config.py

### DIFF
--- a/library/ssh_config.py
+++ b/library/ssh_config.py
@@ -730,7 +730,7 @@ def main():
     hosts_removed = []
     hosts_added = []
 
-    if user is None:
+    if user is None or user == "root":
         config_file = '/etc/ssh/ssh_config'
         user = 'root'
     else:


### PR DESCRIPTION
Allow user to be specified as root and still create global config file, as opposed to `/.ssh/config`