### PR TITLE
Allow for custom ssh_config_file specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ cases of adding, changing and removing hosts from your config file.
               identity_file=id_rsa.internal-lib port=222 state=present
 - name: Remove old-internal-lib.github.com from ssh config
   ssh_config: host=old-internal-lib.github.com state=absent
+
+# Or if using a custom ssh config. One use case for this would be when using openssh7.3+ which supports the Include directive to include all files within a specified directory 
+
+- name: Add internal-lib.github.com to custom ssh config
+  ssh_config: host=internal-lib.github.com hostname=github.com
+              ssh_config_file=/path/to/ssh/config.d/custom_config_file identity_file=id_rsa.internal-lib port=222 state=present
 ```
 
 For the full set of options please look at the top of the module file.

--- a/library/ssh_config.py
+++ b/library/ssh_config.py
@@ -696,7 +696,7 @@ def change_host(options, **kwargs):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-	        ssh_config_file=dict(default=None, type='str'),
+	    ssh_config_file=dict(default=None, type='str'),
             state=dict(default='present', choices=['present', 'absent']),
             host=dict(required=True, type='str'),
             hostname=dict(type='str'),

--- a/library/ssh_config.py
+++ b/library/ssh_config.py
@@ -696,6 +696,7 @@ def change_host(options, **kwargs):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
+	        ssh_config_file=dict(default=None, type='str'),
             state=dict(default='present', choices=['present', 'absent']),
             host=dict(required=True, type='str'),
             hostname=dict(type='str'),
@@ -715,6 +716,8 @@ def main():
 
     user = module.params.get('user')
     host = module.params.get('host')
+    ssh_config_file = module.params.get('ssh_config_file')
+
     args = dict(
         hostname=module.params.get('hostname'),
         port=module.params.get('port'),
@@ -734,9 +737,12 @@ def main():
         config_file = '/etc/ssh/ssh_config'
         user = 'root'
     else:
-        config_file = os.path.join(
-            os.path.expanduser('~{0}'.format(user)), '.ssh', 'config'
-        )
+	if ssh_config_file is None:
+        	config_file = os.path.join(
+            	os.path.expanduser('~{0}'.format(user)), '.ssh', 'config'
+        	)
+	else:
+		config_file = module.params.get('ssh_config_file')
 
     # See if the identity file exists or not, relative to the config file
     if os.path.exists(config_file) and args['identity_file']:

--- a/library/ssh_config.py
+++ b/library/ssh_config.py
@@ -696,7 +696,7 @@ def change_host(options, **kwargs):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-	    ssh_config_file=dict(default=None, type='str'),
+            ssh_config_file=dict(default=None, type='str'),
             state=dict(default='present', choices=['present', 'absent']),
             host=dict(required=True, type='str'),
             hostname=dict(type='str'),


### PR DESCRIPTION
Allow for custom ssh_config_file specification. One use case is in openssh 7.3+ which supports the Include directive to include all files within a directory 